### PR TITLE
update package.json with raml-paser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "through2": "~0.4.1",
     "chalk": "~0.4.0",
     "map-stream": "~0.1.0",
-    "text-table": "~0.2.0"
+    "text-table": "~0.2.0", 
+    "raml-parser":"~0.8.7"
   }
 }


### PR DESCRIPTION
Hi, 
thanks for the raml validator!

you need raml-parser in your dependencies, if someone wants to use it without install it by himself.
If not, you got the following error while running the task: 

module.js:340
    throw err;
          ^
Error: Cannot find module 'raml-parser'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (D:\Projets\GitHub\gulp-raml\node_modules\gulp-raml\src\index.js:5:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (D:\Projets\GitHub\gulp-raml\gulpfile.js:1:74)
